### PR TITLE
chore: add shared Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>Boshen/renovate", "config:recommended"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
+  "automerge": true
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,0 @@
-{
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:recommended"],
-	"lockFileMaintenance": {
-		"enabled": true,
-		"automerge": true
-	},
-	"automerge": true
-}


### PR DESCRIPTION
## Summary
- add or normalize `.github/renovate.json`
- make `github>Boshen/renovate` the first Renovate preset

## Verification
- parsed `.github/renovate.json` with `jq`
- verified `.extends[0] == "github>Boshen/renovate"`