### PR TITLE
chore: use shared renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>Boshen/renovate", "config:recommended"],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true
-  },
-  "automerge": true
+  "extends": ["github>Boshen/renovate"]
 }


### PR DESCRIPTION
Use the shared `Boshen/renovate` preset as the sole Renovate configuration, centralizing dependency-update behavior. The JSON configuration parses successfully.